### PR TITLE
Fix ambiguity warning

### DIFF
--- a/lib/cldr_strftime.ex
+++ b/lib/cldr_strftime.ex
@@ -99,5 +99,5 @@ defmodule Cldr.Strftime do
   end
 
   defp unwrap_ok!({:ok, term}), do: term
-  defp unwrap_ok!({:error, {exception, message}}), do: raise exception, message
+  defp unwrap_ok!({:error, {exception, message}}), do: raise(exception, message)
 end


### PR DESCRIPTION
~~~elixir
warning: missing parentheses for expression following "do:" keyword. Parentheses are required to solve ambiguity inside keywords.

This error happens when you have function calls without parentheses inside keywords. For example:

    function(arg, one: nested_call a, b, c)
    function(arg, one: if expr, do: :this, else: :that)

In the examples above, we don't know if the arguments "b" and "c" apply to the function "function" or "nested_call". Or if the keywords "do" and "else" apply to the function "function" or "if". You can solve this by explicitly adding parentheses:

    function(arg, one: if(expr, do: :this, else: :that))
    function(arg, one: nested_call(a, b, c))

Ambiguity found at:
  lib/cldr_strftime.ex:102
~~~